### PR TITLE
[Fix] #215 - 로그아웃, 회원탈퇴 API 수정

### DIFF
--- a/GEON-PPANG-iOS/Global/Network/API/Auth/AuthAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/Auth/AuthAPI.swift
@@ -13,7 +13,6 @@ final class AuthAPI {
     
     typealias SignUpResponse = GeneralResponse<SignUpResponseDTO>
     typealias TokenRefreshResponse = GeneralResponse<VoidType>
-    typealias DeleteUserResponse = GeneralResponse<DeleteUserResponseDTO>
     
     static let shared: AuthAPI = AuthAPI()
     
@@ -23,7 +22,6 @@ final class AuthAPI {
     
     public private(set) var signUpResponse: SignUpResponse?
     public private(set) var tokenRefreshResponse: TokenRefreshResponse?
-    public private(set) var deleteUserResponse: DeleteUserResponse?
     
     // MARK: - Post
     
@@ -104,36 +102,4 @@ final class AuthAPI {
         }
     }
     
-    func logout(completion: @escaping (Int?) -> Void) {
-        
-        authProvider.request(.logout) { result in
-            switch result {
-            case .success(let response):
-                completion(response.statusCode)
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil)
-            }
-        }
-    }
-    
-    func deleteUser(completion: @escaping (DeleteUserResponse?) -> Void) {
-        
-        let type = KeychainService.readKeychain(of: .socialType)
-        authProvider.request(type == "APPLE" ? .appleWithdraw : .withdraw) { result in
-            switch result {
-            case .success(let response):
-                do {
-                    self.deleteUserResponse = try response.map(DeleteUserResponse.self)
-                    guard let deleteUserResponse = self.deleteUserResponse else { return }
-                    completion(deleteUserResponse)
-                } catch let err {
-                    print(err.localizedDescription, 500)
-                }
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil)
-            }
-        }
-    }
 }

--- a/GEON-PPANG-iOS/Global/Network/Service/Auth/AuthService.swift
+++ b/GEON-PPANG-iOS/Global/Network/Service/Auth/AuthService.swift
@@ -15,9 +15,6 @@ enum AuthService {
     case login(request: LoginRequestDTO)
     case signUp(request: SignUpRequestDTO)
     case refreshToken
-    case withdraw
-    case appleWithdraw
-    case logout
 }
 
 extension AuthService: TargetType {
@@ -37,21 +34,15 @@ extension AuthService: TargetType {
             return URLConstant.signup
         case .refreshToken:
             return URLConstant.refreshToken
-        case .logout:
-            return URLConstant.logout
-        case .withdraw, .appleWithdraw:
-            return URLConstant.withdraw
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .checkEmail, .checkNickname, .login, .signUp, .logout:
+        case .checkEmail, .checkNickname, .login, .signUp:
             return .post
         case .refreshToken:
             return .get
-        case .withdraw, .appleWithdraw:
-            return .delete
         }
     }
     
@@ -67,10 +58,6 @@ extension AuthService: TargetType {
             return .requestJSONEncodable(data)
         case .refreshToken:
             return .requestPlain
-        case .logout:
-            return .requestPlain
-        case .withdraw, .appleWithdraw:
-            return .requestPlain
         }
     }
     
@@ -82,12 +69,6 @@ extension AuthService: TargetType {
             return NetworkConstant.header(.platformToken)
         case .refreshToken:
             return NetworkConstant.header(.accessAndRefreshToken)
-        case .logout:
-            return NetworkConstant.header(.accessToken)
-        case .withdraw:
-            return NetworkConstant.header(.accessToken)
-        case .appleWithdraw:
-            return NetworkConstant.header(.appleRefresh)
         }
     }
 }

--- a/GEON-PPANG-iOS/Global/Network/Service/Member/MemberService.swift
+++ b/GEON-PPANG-iOS/Global/Network/Service/Member/MemberService.swift
@@ -12,6 +12,9 @@ import Moya
 enum MemberService {
     case setNickname(request: NicknameRequestDTO)
     case fetchNickname
+    case withdraw
+    case appleWithdraw
+    case logout
 }
 
 extension MemberService: TargetType {
@@ -23,15 +26,21 @@ extension MemberService: TargetType {
         switch self {
         case .setNickname, .fetchNickname:
             return URLConstant.nickname
+        case .logout:
+            return URLConstant.logout
+        case .withdraw, .appleWithdraw:
+            return URLConstant.withdraw
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .setNickname:
+        case .setNickname, .logout:
             return .post
         case .fetchNickname:
             return .get
+        case .withdraw, .appleWithdraw:
+            return .delete
         }
     }
     
@@ -40,6 +49,10 @@ extension MemberService: TargetType {
         case .setNickname(request: let data):
             return .requestJSONEncodable(data)
         case .fetchNickname:
+            return .requestPlain
+        case .logout:
+            return .requestPlain
+        case .withdraw, .appleWithdraw:
             return .requestPlain
         }
     }
@@ -50,6 +63,12 @@ extension MemberService: TargetType {
             return NetworkConstant.header(.accessToken)
         case .fetchNickname:
             return NetworkConstant.header(.accessToken)
+        case .logout:
+            return NetworkConstant.header(.accessToken)
+        case .withdraw:
+            return NetworkConstant.header(.accessToken)
+        case .appleWithdraw:
+            return NetworkConstant.header(.appleRefresh)
         }
     }
     

--- a/GEON-PPANG-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -160,7 +160,7 @@ extension MyPageViewController {
     
     func logout() {
         
-        AuthAPI.shared.logout { code in
+        MemberAPI.shared.logout { code in
             switch code {
             case 200:
                 KeychainService.deleteKeychain(of: .access)
@@ -177,14 +177,14 @@ extension MyPageViewController {
     
     func deleteUser() {
         
-        AuthAPI.shared.deleteUser { response in
+        MemberAPI.shared.deleteUser { response in
             switch response?.code {
             case 200:
-                KeychainService.deleteAllAuthKeychains()
                 if KeychainService.readKeychain(of: .socialType) == "KAKAO" {
                     KakaoService.unlink()
                 }
                 Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
+                KeychainService.deleteAllAuthKeychains()
             default:
                 if let child = self.children.first {
                     child.dismiss(animated: true)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
기존에 로그아웃과 회원탈퇴 API 가 문제가 있었는데, 그 이유가 AuthAPI 쪽에 위치해있기 때문입니다

AuthAPI 에는 Provider 에 따로 추가적인 plugin 을 없이 했는데,
(여기서는 retry 를 통해 토큰 리프레시 적용하면 안되기 때문)
그렇다보니 회원탈퇴 할 때에도 만료된 토큰 갖고는 통신이 안되게 됩니다

이 때문에 회원탈퇴 및 로그아웃 시도시 토큰이 만료돼서 탈퇴 & 로그아웃이 안되는 경우도 있게 된다
그러면, 이런 경우에서는 토큰 재발급 되도록 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- logout: AuthAPI -> MemberAPI 
- deleteUser: AuthAPI -> MemberAPI 

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #215 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
