### PR TITLE
[리젝 이후] 403 오류가 뜨는걸 해결하기 위한 이슈

### DIFF
--- a/GEON-PPANG-iOS/Application/SceneDelegate.swift
+++ b/GEON-PPANG-iOS/Application/SceneDelegate.swift
@@ -70,4 +70,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
         }
     }
+    
+    func changeRootViewControllerTo(_ viewController: UIViewController) {
+        guard let window = window else { return }
+        
+        DispatchQueue.main.async {
+            let rootViewController = viewController
+            let navigationController = UINavigationController(rootViewController: rootViewController)
+            navigationController.isNavigationBarHidden = true
+            window.rootViewController = navigationController
+            UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
+        }
+    }
 }

--- a/GEON-PPANG-iOS/Application/SceneDelegate.swift
+++ b/GEON-PPANG-iOS/Application/SceneDelegate.swift
@@ -10,22 +10,24 @@ import UIKit
 import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
             
-            let rootViewController = LaunchScreenViewController()
-            let navigationController = UINavigationController(rootViewController: rootViewController)
-            navigationController.isNavigationBarHidden = true
-            window.rootViewController = navigationController
-            window.makeKeyAndVisible()
-            self.window = window
+            DispatchQueue.main.async {
+                let rootViewController = LaunchScreenViewController()
+                let navigationController = UINavigationController(rootViewController: rootViewController)
+                navigationController.isNavigationBarHidden = true
+                window.rootViewController = navigationController
+                window.makeKeyAndVisible()
+                self.window = window
+            }
         }
     }
     
@@ -38,30 +40,34 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {}
-
+    
     func sceneWillResignActive(_ scene: UIScene) {}
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {}
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {}
     
     func changeRootViewControllerToTabBarController() {
         guard let window = window else { return }
-        let rootViewController = TabBarController()
-        let navigationController = UINavigationController(rootViewController: rootViewController)
-        navigationController.isNavigationBarHidden = true
-        window.rootViewController = navigationController
-        UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
+        DispatchQueue.main.async {
+            let rootViewController = TabBarController()
+            let navigationController = UINavigationController(rootViewController: rootViewController)
+            navigationController.isNavigationBarHidden = true
+            window.rootViewController = navigationController
+            UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
+        }
     }
     
     func changeRootViewControllerToOnboardingViewController() {
         guard let window = window else { return }
-        let rootViewController = OnboardingViewController()
-        let navigationController = UINavigationController(rootViewController: rootViewController)
-        navigationController.isNavigationBarHidden = true
-        window.rootViewController = navigationController
-        UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
+        DispatchQueue.main.async {
+            let rootViewController = OnboardingViewController()
+            let navigationController = UINavigationController(rootViewController: rootViewController)
+            navigationController.isNavigationBarHidden = true
+            window.rootViewController = navigationController
+            UIView.transition(with: window, duration: 0.2, options: [.transitionCrossDissolve], animations: nil)
+        }
     }
 }

--- a/GEON-PPANG-iOS/Global/Network/API/AuthAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/AuthAPI.swift
@@ -12,7 +12,7 @@ import Moya
 protocol AuthAPIType {
     func postLogin(request: LoginRequestDTO, completion: @escaping (Int?) -> Void)
     func postSignUp(request: SignUpRequestDTO, completion: @escaping (Endpoint<SignUpResponseDTO>?) -> Void)
-    func getTokenRefresh(completion: @escaping (Endpoint<VoidType>?) -> Void)
+    func getTokenRefresh(completion: @escaping (Int?) -> Void)
     func logout(completion: @escaping (Int?) -> Void)
     func deleteUser(completion: @escaping (Endpoint<DeleteUserResponseDTO>?) -> Void)
 }
@@ -22,10 +22,9 @@ final class AuthAPI: AuthAPIType {
     static let shared: AuthAPI = AuthAPI()
     private init() {}
     
-    var defaultProvider: MoyaProvider<AuthService> = MoyaProvider(session: Session(interceptor: AuthInterceptor.shared),
-                                                                  plugins: [MoyaLoggingPlugin()])
+    var defaultProvider: MoyaProvider<AuthService> = MoyaProvider(plugins: [AuthPlugin()])
     
-    var tokenProvider : MoyaProvider<AuthService> = MoyaProvider<AuthService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [AuthPlugin()])
+    var tokenProvider: MoyaProvider<AuthService> = MoyaProvider<AuthService>(session: Session(interceptor: AuthInterceptor.shared), plugins: [AuthPlugin()])
     
     func postLogin(request: LoginRequestDTO, completion: @escaping (Int?) -> Void) {
         defaultProvider.request(.login(request: request)) { result in
@@ -62,19 +61,19 @@ final class AuthAPI: AuthAPIType {
         }
     }
     
-    func getTokenRefresh(completion: @escaping (Endpoint<VoidType>?) -> Void) {
+    func getTokenRefresh(completion: @escaping (Int?) -> Void) {
         defaultProvider.request(.refreshToken) { result in
             switch result {
             case .success(let response):
                 do {
                     let response = try response.map(Endpoint<VoidType>.self)
-                    completion(response)
+                    completion(response.code)
                 } catch let err {
                     print(err.localizedDescription, 500)
                 }
             case .failure(let err):
                 print(err.localizedDescription)
-                completion(nil)
+                completion(err.errorCode)
             }
         }
     }

--- a/GEON-PPANG-iOS/Global/Network/API/AuthAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/AuthAPI.swift
@@ -62,7 +62,7 @@ final class AuthAPI: AuthAPIType {
     }
     
     func getTokenRefresh(completion: @escaping (Int?) -> Void) {
-        defaultProvider.request(.refreshToken) { result in
+        tokenProvider.request(.refreshToken) { result in
             switch result {
             case .success(let response):
                 do {
@@ -73,7 +73,7 @@ final class AuthAPI: AuthAPIType {
                 }
             case .failure(let err):
                 print(err.localizedDescription)
-                completion(err.errorCode)
+                completion(err.response?.statusCode)
             }
         }
     }

--- a/GEON-PPANG-iOS/Global/Network/API/MemberAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/MemberAPI.swift
@@ -13,7 +13,7 @@ protocol MemberAPIType {
     func postFilter(request: FilterRequestDTO, completion: @escaping (ArrayEndpoint<FilterResponseDTO>?) -> Void)
     func getFilter(completion: @escaping (Endpoint<FilterResponseDTO>?) -> Void)
     func postNickname(request: NicknameRequestDTO, completion: @escaping (Endpoint<SetNicknameResponseDTO>?) -> Void)
-    func getNickname(completion: @escaping (Endpoint<FetchNicknameResponseDTO>?) -> Void)
+    func getNickname(completion: @escaping (Endpoint<FetchNicknameResponseDTO>?, Int?) -> Void)
     func bookmarks(completion: @escaping (ArrayEndpoint<BakeryCommonListResponseDTO>?) -> Void)
     func reviews(completion: @escaping (ArrayEndpoint<MyReviewsResponseDTO>?) -> Void)
     func member(completion: @escaping (Endpoint<MyPageResponseDTO>?) -> Void)
@@ -78,19 +78,19 @@ final class MemberAPI: MemberAPIType {
         }
     }
     
-    func getNickname(completion: @escaping (Endpoint<FetchNicknameResponseDTO>?) -> Void) {
+    func getNickname(completion: @escaping (Endpoint<FetchNicknameResponseDTO>?, Int?) -> Void) {
         provider.request(.getNickname) { result in
             switch result {
             case .success(let response):
                 do {
                     let response = try response.map(Endpoint<FetchNicknameResponseDTO>.self)
-                    completion(response)
-                } catch let err {
-                    print(err)
+                    completion(response, nil)
+                } catch _ {
+                    completion(nil, nil)
                 }
             case .failure(let err):
                 print(err.localizedDescription)
-                completion(nil)
+                completion(nil, err.response?.statusCode)
             }
         }
     }
@@ -145,5 +145,4 @@ final class MemberAPI: MemberAPIType {
             }
         }
     }
-    
 }

--- a/GEON-PPANG-iOS/Global/Network/API/ReviewsAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/ReviewsAPI.swift
@@ -33,8 +33,7 @@ final class ReviewsAPI: ReviewsAPIType {
                     #if DEBUG
                     print("✅\(response)")
                     #endif
-                }
-                catch let err {
+                } catch let err {
                     print(err.localizedDescription)
                     completion(nil)
                 }

--- a/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
+++ b/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
@@ -27,7 +27,8 @@ final class AuthInterceptor: RequestInterceptor {
         
         let authorization = KeychainService.readKeychain(of: .access)
         var urlRequest = urlRequest
-        urlRequest.setValue("Bearer " + authorization, forHTTPHeaderField: "Authorization")
+        
+        urlRequest.headers.add(.authorization(bearerToken: authorization))
         
         completion(.success(urlRequest))
     }
@@ -48,10 +49,14 @@ final class AuthInterceptor: RequestInterceptor {
             return
         }
         
+        if KeychainService.readKeychain(of: .access) == "" {
+            Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
+        }
+        
         AuthAPI.shared.getTokenRefresh { response in
             guard let response = response else { return }
             
-            if response.code == 200 {
+            if response == 200 {
                 completion(.retry)
             } else {
                 Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()

--- a/GEON-PPANG-iOS/Global/Network/Service/MemberService.swift
+++ b/GEON-PPANG-iOS/Global/Network/Service/MemberService.swift
@@ -79,5 +79,3 @@ extension MemberService: GBService {
     }
     
 }
-
-

--- a/GEON-PPANG-iOS/Global/Utils/Utils.swift
+++ b/GEON-PPANG-iOS/Global/Utils/Utils.swift
@@ -70,5 +70,9 @@ final class Utils {
         AnalyticManager.log(event: .detail(.viewDetailpageAt(source: source.rawValue)))
     }
     
-    static var sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+    static var sceneDelegate: SceneDelegate? {
+        return DispatchQueue.main.sync {
+            return UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+        }
+    }
 }

--- a/GEON-PPANG-iOS/Global/Utils/Utils.swift
+++ b/GEON-PPANG-iOS/Global/Utils/Utils.swift
@@ -70,9 +70,6 @@ final class Utils {
         AnalyticManager.log(event: .detail(.viewDetailpageAt(source: source.rawValue)))
     }
     
-    static var sceneDelegate: SceneDelegate? {
-        return DispatchQueue.main.sync {
-            return UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-        }
-    }
+    static var sceneDelegate: SceneDelegate? = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+    
 }

--- a/GEON-PPANG-iOS/Presentation/Filter/ViewControllers/FilterViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/Filter/ViewControllers/FilterViewController.swift
@@ -345,5 +345,4 @@ extension FilterViewController: UICollectionViewDelegate {
             configureNextButton()
         }
     }
-    
 }

--- a/GEON-PPANG-iOS/Presentation/LaunchScreen/LaunchScreenViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/LaunchScreen/LaunchScreenViewController.swift
@@ -42,7 +42,13 @@ final class LaunchScreenViewController: BaseViewController {
     
     private func checkUserLoggedIn() {
         
-        getNickname { nickname in
+        getNickname { nickname, err in
+            if err  == 403 {
+                let viewcontroller = NickNameViewController()
+                viewcontroller.naviView.hideBackButton(true)
+                Utils.push(self.navigationController, viewcontroller)
+            }
+            
             guard let nickname = nickname else {
                 Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
                 return
@@ -62,17 +68,21 @@ final class LaunchScreenViewController: BaseViewController {
 
 extension LaunchScreenViewController {
     
-    private func getNickname(_ completion: @escaping (String?) -> Void) {
+    private func getNickname(_ completion: @escaping (String?, Int?) -> Void) {
         
-        MemberAPI.shared.getNickname { result in
+        MemberAPI.shared.getNickname { result, err in
+            
+            if err == 403 { completion(nil, err); return }
+            
             guard let result = result,
                   let response = result.data
-            else { return }
+            else { completion(nil, nil); return }
+            
             switch result.code {
             case 200:
-                completion(response.nickname)
+                completion(response.nickname, nil)
             default:
-                completion(nil)
+                completion(nil, nil)
             }
         }
     }

--- a/GEON-PPANG-iOS/Presentation/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -147,7 +147,7 @@ final class OnboardingViewController: BaseViewController {
                 )
                 
                 self?.postSignUp(with: request) {
-                    self?.getNickname { nickname in
+                    self?.getNickname { nickname, err in
                         self?.checkNickname(nickname)
                     }
                 }
@@ -225,17 +225,21 @@ extension OnboardingViewController {
         }
     }
     
-    private func getNickname(_ completion: @escaping (String?) -> Void) {
+    private func getNickname(_ completion: @escaping (String?, Int?) -> Void) {
         
-        MemberAPI.shared.getNickname { result in
+        MemberAPI.shared.getNickname { result, err  in
+            
+            if err == 403 { completion(nil, err); return }
+            
             guard let result = result,
                   let response = result.data
-            else { return }
+            else {  completion(nil,nil); return }
+
             switch result.code {
             case 200:
-                completion(response.nickname)
+                completion(response.nickname, nil)
             default:
-                completion(nil)
+                completion(nil, nil)
             }
         }
     }
@@ -280,7 +284,7 @@ extension OnboardingViewController: ASAuthorizationControllerDelegate {
                 )
                 
                 self.postSignUp(with: request) {
-                    self.getNickname { nickname in
+                    self.getNickname { nickname, err in
                         self.checkNickname(nickname)
                     }
                 }


### PR DESCRIPTION
## 🌁 Background
auth API, member API 수정 


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

| iPhone SE2 | iPhone 13 mini | iPhone 13 Pro |
|----|----|----|
|  |  |  |


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

getNickname 
-> 401 / 403 가 왔을 때 원래는 success 로 넘어갔는데, 이제는 서버가 header에 에러처리를 해서 moya 에서도 에러라고 판단해서 failure 로 넘어감
-> failure에서 아무 처리를 안해주고 있기 때문에 getNickname 부분에서 401/403이 뜰 때 guard let 으로 처리를 하는데, 여기서 넘어가지 못해 문제가 발생
-> escaping으로 error 넘겨줘서 error 분기 처리함 
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #233


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
