### PR TITLE
[Fix] #235 - 리젝 이후 auth 쪽 api 수정

### DIFF
--- a/GEON-PPANG-iOS/Global/Enum/AlertEnum.swift
+++ b/GEON-PPANG-iOS/Global/Enum/AlertEnum.swift
@@ -42,7 +42,7 @@ enum AlertType {
     var image: UIImage {
         switch self {
         case .logout: return .sadIcon
-        case .leave: return .smileIcon
+        case .leave: return .sadIcon
         }
     }
 }

--- a/GEON-PPANG-iOS/Global/Network/API/ValidationAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/ValidationAPI.swift
@@ -41,7 +41,7 @@ final class ValidationAPI: ValidationAPIType {
                 completion(response.statusCode)
             case .failure(let err):
                 print(err.localizedDescription)
-                completion(nil)
+                completion(err.response?.statusCode)
             }
         }
     }

--- a/GEON-PPANG-iOS/Global/Network/API/ValidationAPI.swift
+++ b/GEON-PPANG-iOS/Global/Network/API/ValidationAPI.swift
@@ -19,8 +19,7 @@ final class ValidationAPI: ValidationAPIType {
     static let shared: ValidationAPI = ValidationAPI()
     private init() {}
     
-    var provider: MoyaProvider<ValidationService> = MoyaProvider(session: Session(interceptor: AuthInterceptor.shared),
-                                                                 plugins: [MoyaLoggingPlugin()])
+    var provider: MoyaProvider<ValidationService> = MoyaProvider(plugins: [MoyaLoggingPlugin()])
     
     func postCheckEmail(request: EmailRequestDTO, completion: @escaping (Int?) -> Void) {
         provider.request(.checkEmail(request: request)) { result in

--- a/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
+++ b/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
@@ -35,6 +35,13 @@ final class AuthInterceptor: RequestInterceptor {
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         
+        guard KeychainService.hasKeychain(of: .access) else {
+            DispatchQueue.main.async {
+                Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
+            }
+            return
+        }
+        
         guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
         else {
             completion(.doNotRetry)
@@ -47,10 +54,6 @@ final class AuthInterceptor: RequestInterceptor {
                 Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
             }
             return
-        }
-        
-        if KeychainService.readKeychain(of: .access) == "" {
-            Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
         }
         
         AuthAPI.shared.getTokenRefresh { response in

--- a/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
+++ b/GEON-PPANG-iOS/Global/Network/Base/AuthInterceptor.swift
@@ -35,16 +35,16 @@ final class AuthInterceptor: RequestInterceptor {
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
+        else {
+            completion(.doNotRetry)
+            return
+        }
+        
         guard KeychainService.hasKeychain(of: .access) else {
             DispatchQueue.main.async {
                 Utils.sceneDelegate?.changeRootViewControllerToOnboardingViewController()
             }
-            return
-        }
-        
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
-        else {
-            completion(.doNotRetry)
             return
         }
         

--- a/GEON-PPANG-iOS/Presentation/NickName/NickNameViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/NickName/NickNameViewController.swift
@@ -100,6 +100,7 @@ final class NickNameViewController: BaseViewController {
         }
         
         checkButton.do {
+            $0.isEnabled = false
             $0.configureButtonUI(.clear)
             $0.configureBorder(1, .gbbGray300)
             $0.configureButtonTitle(.duplicate)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

| iPhone SE2 | iPhone 13 mini | iPhone 13 Pro |
|----|----|----|
|  |  |  |


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 지난번에 같이 작업하고 난 뒤에도 계속 앱이 터지는 문제가 생겼는데, 
알아보니 authInterceptor에서 accessToken 이 없는 경우에도 retry 를 계속 시도하다 문제가 발생해서 그런 것 같더라구요 
-> 그래서 guard 문으로 accessToken 있을 때에만 retry 하라고 했습니닷

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #235


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
