### PR TITLE
[Fix] #260 - 무한 스크롤 과정에서 발생한 메모리 사용량 개선 및 레이아웃 계산 최적화

### DIFF
--- a/GEON-PPANG-iOS.xcodeproj/project.pbxproj
+++ b/GEON-PPANG-iOS.xcodeproj/project.pbxproj
@@ -253,7 +253,6 @@
 		DFD93D132AC6F28B008E9EE1 /* ReportRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD93D122AC6F28B008E9EE1 /* ReportRequestDTO.swift */; };
 		DFD93D152AC6F649008E9EE1 /* ReportResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD93D142AC6F649008E9EE1 /* ReportResponseDTO.swift */; };
 		DFDE72D72A65E84700389A51 /* WrittenReviewsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDE72D62A65E84700389A51 /* WrittenReviewsCollectionViewCell.swift */; };
-		DFDE72DB2A66893900389A51 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = DFDE72DA2A66893900389A51 /* Config.xcconfig */; };
 		DFDE72DD2A668FFE00389A51 /* ReviewCategoryStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDE72DC2A668FFE00389A51 /* ReviewCategoryStackView.swift */; };
 		DFEA34EF2AA62E6200524DEC /* LinkButtonStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFEA34EE2AA62E6200524DEC /* LinkButtonStackView.swift */; };
 		DFECBB082A690DBB007F054B /* BakeryDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFECBB072A690DBB007F054B /* BakeryDetailResponseDTO.swift */; };
@@ -332,6 +331,7 @@
 		098F32EC2A4200FE0092D09A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		098F32EE2A4200FE0092D09A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		09980CFA2A99A9800098550C /* SignInPropertyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPropertyType.swift; sourceTree = "<group>"; };
+		09A994A32BFD119A007A8098 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		09B13F472A5931DC00C0C723 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		09B13F4B2A593C6F00C0C723 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		09B13F4F2A593CB800C0C723 /* BakeryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakeryListViewController.swift; sourceTree = "<group>"; };
@@ -383,7 +383,6 @@
 		3E35432F2AAC700600BD926A /* SignUpRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestDTO.swift; sourceTree = "<group>"; };
 		3E3543312AAC707200BD926A /* PlatformEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformEnum.swift; sourceTree = "<group>"; };
 		3E3543332AAD594E00BD926A /* SignUpResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResponseDTO.swift; sourceTree = "<group>"; };
-		3E36D7D22A8E15C200B2C1CC /* GEON-PPANG-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "GEON-PPANG-iOS.entitlements"; sourceTree = "<group>"; };
 		3E36D7D52A8E6AF000B2C1CC /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
 		3E36D7D72A8E6BC500B2C1CC /* FilterDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterDiffableDataSource.swift; sourceTree = "<group>"; };
 		3E36D7D92A8E758A00B2C1CC /* FilterCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCellModel.swift; sourceTree = "<group>"; };
@@ -503,7 +502,6 @@
 		DFD93D122AC6F28B008E9EE1 /* ReportRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRequestDTO.swift; sourceTree = "<group>"; };
 		DFD93D142AC6F649008E9EE1 /* ReportResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportResponseDTO.swift; sourceTree = "<group>"; };
 		DFDE72D62A65E84700389A51 /* WrittenReviewsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrittenReviewsCollectionViewCell.swift; sourceTree = "<group>"; };
-		DFDE72DA2A66893900389A51 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		DFDE72DC2A668FFE00389A51 /* ReviewCategoryStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCategoryStackView.swift; sourceTree = "<group>"; };
 		DFEA34EE2AA62E6200524DEC /* LinkButtonStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkButtonStackView.swift; sourceTree = "<group>"; };
 		DFECBB072A690DBB007F054B /* BakeryDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakeryDetailResponseDTO.swift; sourceTree = "<group>"; };
@@ -532,13 +530,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0905561C2A51DAF900752067 /* Design */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Design;
-			sourceTree = "<group>";
-		};
 		090556232A51DB7A00752067 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -811,7 +802,6 @@
 			isa = PBXGroup;
 			children = (
 				090556232A51DB7A00752067 /* UI */,
-				0905561C2A51DAF900752067 /* Design */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -857,8 +847,6 @@
 		0961C36B2A501F050031A822 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
-				DFDE72DA2A66893900389A51 /* Config.xcconfig */,
-				3E36D7D22A8E15C200B2C1CC /* GEON-PPANG-iOS.entitlements */,
 				098F32EE2A4200FE0092D09A /* Info.plist */,
 				094392CE2A84E68700984310 /* GoogleService-Info.plist */,
 				0961C36F2A501F4C0031A822 /* Storyboard */,
@@ -929,6 +917,7 @@
 		098F32D42A4200FD0092D09A = {
 			isa = PBXGroup;
 			children = (
+				09A994A32BFD119A007A8098 /* Config.xcconfig */,
 				091AFD412ABD79380001DD02 /* Settings.bundle */,
 				098F32DF2A4200FD0092D09A /* GEON-PPANG-iOS */,
 				098F32DE2A4200FD0092D09A /* Products */,
@@ -1955,7 +1944,6 @@
 				DF959A612A539FBE00E75774 /* Pretendard-Bold.otf in Resources */,
 				094392CF2A84E68700984310 /* GoogleService-Info.plist in Resources */,
 				098F32ED2A4200FE0092D09A /* LaunchScreen.storyboard in Resources */,
-				DFDE72DB2A66893900389A51 /* Config.xcconfig in Resources */,
 				098F32EA2A4200FE0092D09A /* Assets.xcassets in Resources */,
 				DF959A622A539FBE00E75774 /* Pretendard-Medium.otf in Resources */,
 				091AFD422ABD79380001DD02 /* Settings.bundle in Resources */,
@@ -2248,7 +2236,7 @@
 /* Begin XCBuildConfiguration section */
 		098F32EF2A4200FE0092D09A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFDE72DA2A66893900389A51 /* Config.xcconfig */;
+			baseConfigurationReference = 09A994A32BFD119A007A8098 /* Config.xcconfig */;
 			buildSettings = {
 				ACCESS_TOKEN = "${ACCESS_TOKEN}";
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2311,7 +2299,7 @@
 		};
 		098F32F02A4200FE0092D09A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFDE72DA2A66893900389A51 /* Config.xcconfig */;
+			baseConfigurationReference = 09A994A32BFD119A007A8098 /* Config.xcconfig */;
 			buildSettings = {
 				ACCESS_TOKEN = "${ACCESS_TOKEN}";
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2368,7 +2356,7 @@
 		};
 		098F32F22A4200FE0092D09A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFDE72DA2A66893900389A51 /* Config.xcconfig */;
+			baseConfigurationReference = 09A994A32BFD119A007A8098 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = AppIcon;
@@ -2408,7 +2396,7 @@
 		};
 		098F32F32A4200FE0092D09A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFDE72DA2A66893900389A51 /* Config.xcconfig */;
+			baseConfigurationReference = 09A994A32BFD119A007A8098 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = AppIcon;

--- a/GEON-PPANG-iOS.xcodeproj/project.pbxproj
+++ b/GEON-PPANG-iOS.xcodeproj/project.pbxproj
@@ -332,7 +332,6 @@
 		098F32EC2A4200FE0092D09A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		098F32EE2A4200FE0092D09A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		09980CFA2A99A9800098550C /* SignInPropertyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPropertyType.swift; sourceTree = "<group>"; };
-		09A994A32BFD119A007A8098 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		09B13F472A5931DC00C0C723 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		09B13F4B2A593C6F00C0C723 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		09B13F4F2A593CB800C0C723 /* BakeryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakeryListViewController.swift; sourceTree = "<group>"; };
@@ -851,7 +850,6 @@
 			isa = PBXGroup;
 			children = (
 				09E30E892BFF123C001E107B /* Config.xcconfig */,
-				3E36D7D22A8E15C200B2C1CC /* GEON-PPANG-iOS.entitlements */,
 				098F32EE2A4200FE0092D09A /* Info.plist */,
 				094392CE2A84E68700984310 /* GoogleService-Info.plist */,
 				0961C36F2A501F4C0031A822 /* Storyboard */,
@@ -922,7 +920,6 @@
 		098F32D42A4200FD0092D09A = {
 			isa = PBXGroup;
 			children = (
-				09A994A32BFD119A007A8098 /* Config.xcconfig */,
 				091AFD412ABD79380001DD02 /* Settings.bundle */,
 				09E30E812BFEF16F001E107B /* ci_scripts */,
 				098F32DF2A4200FD0092D09A /* GEON-PPANG-iOS */,

--- a/GEON-PPANG-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GEON-PPANG-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,104 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
+        "version" : "5.8.1"
+      }
+    },
+    {
+      "identity" : "amplitude-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-iOS",
+      "state" : {
+        "branch" : "main",
+        "revision" : "82fc62448292c13fa0a6b0b11c4524df83fd3f3b"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "e2ca17ac735bcbc48b13062484541702ef45153d",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "ae3c60cbd4e3b348775f8c766e5b908fa1e66c5a",
+        "version" : "2.20.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "branch" : "master",
+        "revision" : "10a9dd1577c4de5135a29f99410863d2e9ee034a"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "b847a202a517a90763e8fd0656d8028aeee7b78d",
+        "version" : "8.20.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "e74fe2a978d1216c3602b129447c7301573cc2d8",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/GEON-PPANG-iOS/Presentation/Scene/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/Scene/Auth/LogIn/ViewController/LogInViewController.swift
@@ -16,8 +16,8 @@ final class LogInViewController: BaseViewController {
     
     private var loginEmail: String = ""
     private var loginPassword: String = ""
-    private var IsEmailValid: Bool = false
-    private var IsPasswordValid: Bool = false
+    private var isEmailValid: Bool = false
+    private var isPasswordValid: Bool = false
     private var isValid: Bool = false {
         didSet {
             configureButtonUI(self.isValid)
@@ -182,15 +182,15 @@ extension LogInViewController: UITextFieldDelegate {
         switch textField {
         case emailTextField.configureTextField():
             self.loginEmail = text
-            self.IsEmailValid = (text.isValidEmail() && !emailTextField.fetchText().isEmpty) ? true : false
+            self.isEmailValid = (text.isValidEmail() && !emailTextField.fetchText().isEmpty) ? true : false
         case passwordTextField.configureTextField():
             self.loginPassword = text
-            self.IsPasswordValid = !passwordTextField.fetchText().isEmpty ? true : false
+            self.isPasswordValid = !passwordTextField.fetchText().isEmpty ? true : false
         default:
             break
         }
         
-        self.isValid = IsEmailValid && IsPasswordValid
+        self.isValid = isEmailValid && isPasswordValid
         configureButtonUI(self.isValid)
     }
     

--- a/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/Cell/BakeryCommonCollectionViewCell.swift
+++ b/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/Cell/BakeryCommonCollectionViewCell.swift
@@ -17,7 +17,8 @@ final class BakeryCommonCollectionViewCell: UICollectionViewCell {
     
     private var breadTypeTag: [String] = []
     private var ingredientList: [BakeryCommonListResponseDTO] = []
-    
+    private var itemSizeCache: [Int: CGSize] = [:]
+
     // MARK: - UI Property
     
     private let markStackView = MarkStackView()
@@ -32,13 +33,14 @@ final class BakeryCommonCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        
         ingredientList = []
+        bakeryImage.kf.cancelDownloadTask()
+        bakeryImage.image = nil
+        itemSizeCache.removeAll()
     }
     
     override init(frame: CGRect) {
-        super.init(frame: .zero)
-        
+        super.init(frame: frame)
         setLayout()
         setUI()
         setRegistration()
@@ -58,7 +60,6 @@ final class BakeryCommonCollectionViewCell: UICollectionViewCell {
             $0.top.equalToSuperview().offset(24)
             $0.leading.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview().inset(24)
-            
         }
         
         contentView.addSubview(bookmarkCount)
@@ -123,45 +124,53 @@ final class BakeryCommonCollectionViewCell: UICollectionViewCell {
     }
     
     func configureReviewsUI() {
-        
         bookmarkCount.removeFromSuperview()
     }
     
     func configureCellUI<T: BakeryListProtocol>(data: T) {
-        
-        bakeryTitle.setLineHeight(by: 1.05, with: data.name)
-        bakeryTitle.lineBreakMode = .byTruncatingTail
+     
         bookmarkCount.configureHomeCell(count: data.bookmarkCount)
         bookmarkCount.setContentHuggingPriority(UILayoutPriority(751), for: .horizontal)
         bookmarkCount.setContentCompressionResistancePriority(UILayoutPriority(751), for: .horizontal)
         
-        guard let url = URL(string: data.picture) else { return }
-        bakeryImage.kf.setImage(with: url, placeholder: UIImage.loading_small)
-        
-        regionStackView.configureListUI(text: data.station)
-        markStackView.getMarkStatus(data.isHACCP, data.isVegan, data.isNonGMO)
-        
-        breadTypeTag = []
-        data.breadTypeList.forEach {
-            breadTypeTag.append($0.toString())
-        }
-        collectionView.reloadData()
+        setupCellUI(name: data.name,
+                    pictureURL: data.picture,
+                    station: data.station,
+                    isHACCP: data.isHACCP,
+                    isVegan: data.isVegan,
+                    isNonGMO: data.isNonGMO,
+                    breadTypeList: data.breadTypeList)
     }
     
     func configureCellUI(data: MyReviewsResponseDTO) {
-        bakeryTitle.setLineHeight(by: 1.05, with: data.name)
+        setupCellUI(name: data.name,
+                    pictureURL: data.picture,
+                    station: data.station,
+                    isHACCP: data.isHACCP, 
+                    isVegan: data.isVegan,
+                    isNonGMO: data.isNonGMO,
+                    breadTypeList: data.breadTypeList)
+    }
+    
+    private func setupCellUI(name: String, pictureURL: String, station: String, isHACCP: Bool, isVegan: Bool, isNonGMO: Bool, breadTypeList: [BreadType]) {
+        bakeryTitle.setLineHeight(by: 1.05, with: name)
         bakeryTitle.lineBreakMode = .byTruncatingTail
         
-        guard let url = URL(string: data.picture) else { return }
-        bakeryImage.kf.setImage(with: url, placeholder: UIImage.loading_small)
+        guard let url = URL(string: pictureURL) else { return }
+        bakeryImage.kf.setImage(
+            with: url,
+            placeholder: UIImage.loading_small,
+            options: [
+                .processor(DownsamplingImageProcessor(size: CGSize(width: 86, height: 86))),
+                .scaleFactor(UIScreen.main.scale),
+                .cacheOriginalImage
+            ])
         
-        regionStackView.configureListUI(text: data.station)
-        markStackView.getMarkStatus(data.isHACCP, data.isVegan, data.isNonGMO)
+        regionStackView.configureListUI(text: station)
+        markStackView.getMarkStatus(isHACCP, isVegan, isNonGMO)
         
-        breadTypeTag = []
-        data.breadTypeList.forEach {
-            breadTypeTag.append($0.toString())
-        }
+        breadTypeTag = breadTypeList.map { $0.toString() }
+        itemSizeCache.removeAll()
         collectionView.reloadData()
     }
 }
@@ -170,7 +179,6 @@ final class BakeryCommonCollectionViewCell: UICollectionViewCell {
 
 extension BakeryCommonCollectionViewCell {
     private func setRegistration() {
-        
         collectionView.register(cell: DescriptionCollectionViewCell.self)
     }
 }
@@ -179,12 +187,10 @@ extension BakeryCommonCollectionViewCell {
 
 extension BakeryCommonCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        
         return breadTypeTag.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
         let cell: DescriptionCollectionViewCell = collectionView.dequeueReusableCell(for: indexPath)
         cell.cellColor = .sub
         cell.configureTagTitle(self.breadTypeTag[indexPath.item])
@@ -196,9 +202,15 @@ extension BakeryCommonCollectionViewCell: UICollectionViewDataSource {
 
 extension BakeryCommonCollectionViewCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let tagTitle = breadTypeTag[indexPath.item]
         
-        let tagTitle = self.breadTypeTag[indexPath.item]
-        let itemSize = tagTitle.size(withAttributes: [NSAttributedString.Key.font: UIFont.captionM2!])
-        return CGSize(width: itemSize.width + 12, height: itemSize.height)
+        guard let cachedSize = itemSizeCache[tagTitle.count] else {
+            let itemSize = tagTitle.size(withAttributes: [NSAttributedString.Key.font: UIFont.captionM2])
+            let finalSize = CGSize(width: itemSize.width + 12, height: itemSize.height)
+            itemSizeCache[tagTitle.count] = finalSize
+            return finalSize
+        }
+        
+        return cachedSize
     }
 }

--- a/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/ViewController/BakeryListViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/ViewController/BakeryListViewController.swift
@@ -265,9 +265,12 @@ extension BakeryListViewController: UICollectionViewDelegate {
 extension BakeryListViewController: UICollectionViewDataSourcePrefetching {
     func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         
+        let serialQueue = DispatchQueue(label: "Decode queue")
         for indexPath in indexPaths {
-            if bakeryList.count - 1 == indexPath.item, !self.isLast {
-                self.getMoreBakeryList()
+            serialQueue.async {
+                if self.bakeryList.count - 1 == indexPath.item, !self.isLast {
+                    self.getMoreBakeryList()
+                }
             }
         }
     }

--- a/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/ViewController/BakeryListViewController.swift
+++ b/GEON-PPANG-iOS/Presentation/Scene/BakeryList/BakeryList/ViewController/BakeryListViewController.swift
@@ -138,7 +138,7 @@ final class BakeryListViewController: BaseViewController {
             $0.tappedCheckBox = { [weak self] tapped in
                 guard let self else { return }
                 guard KeychainService.readKeychain(of: .role) == UserRole.member.rawValue
-                else { 
+                else {
                     Utils.showLoginRequiredSheet(on: self, type: .recommendation)
                     bakerySortView.tappedButton(false)
                     return
@@ -162,6 +162,7 @@ final class BakeryListViewController: BaseViewController {
         bakeryListCollectionView.do {
             $0.delegate = self
             $0.refreshControl = refreshControl
+            $0.prefetchDataSource = self
         }
     }
     
@@ -259,11 +260,15 @@ extension BakeryListViewController: UICollectionViewDelegate {
         Utils.setDetailSourceType(.LIST)
         Utils.push(self.navigationController, nextViewController)
     }
-    
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+}
+
+extension BakeryListViewController: UICollectionViewDataSourcePrefetching {
+    func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         
-        if indexPath.item == bakeryList.count - 1, !self.isLast {
-            getMoreBakeryList()
+        for indexPath in indexPaths {
+            if bakeryList.count - 1 == indexPath.item, !self.isLast {
+                self.getMoreBakeryList()
+            }
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
- 빵집 리스트 무한 스크롤 과정에서 메모리가 급격하게 증가하는 것을 확인하여 downsampling을 통해 문제를 해결하고자함

## 📱 Screenshot
아래 첨부

## 👩‍💻 Contents
**[문제]**

Bakery 리스트를 CollectionView에 무한 스크롤하여 이미지를 로딩하는 과정에서 이미지 로딩 속도가 느리고, 메모리 사용량이 급격하게 늘어나는 문제가 발견됨.

<img width="335" alt="스크린샷 2024-05-22 12 38 25" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/f6970761-f63a-4e72-b6c7-5874f0802eaa">

이미지 로딩 과정에서 Kingfisher를 사용하여 얻은 원본 이미지의 크기를 확인

**`메모리 사용량 분석`**

Bakery 리스트의 메모리 사용량 증가율을 확인하기 위해, 처음부터 리스트의 끝까지 스크롤하여 메모리 사용량을 확인함.

`초기 스크롤 전의 메모리 사용량은 76.4MB로 측정`

<img width="1512" alt="스크린샷 2024-05-22 12 44 06" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/32567b73-468e-429a-8d53-9d602d902f5d">


`스크롤 후의 메모리 사용량은 2.5GB까지 급증함`
<img width="1512" alt="스크린샷 2024-05-22 12 45 19" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/b1e0fcf5-67ea-4e24-b21d-856db11c36d7">



이를 통해 Bakery 리스트의 스크롤 과정에서 메모리 사용량이 비정상적으로 증가하는 것을 확인할 수 있었음.

**[해결 과정]**
이미지 로딩 속도와 메모리 사용량 문제를 해결하기 위해 단순히 이미지 **`resize`** 하는 대신 **`downsampling`** 을 적용해야 함.

**why?** UIImage의 이미지 **`resize`** 는 원본 이미지를 압축하는 방식으로, 처리 과정에서 많은 비용이 발생함.

WWDC18에서 소개된 **Image and Graphics Best Practices** 세션을 참고하여 최적화 방법을 적용.

**🍎 Discussion 정리** : https://github.com/GEON-PPANG/GEON-PPANG-iOS/discussions/262#discussion-6709497

**[결과]**

**Kingfisher를 통한 Downsampling**

프로젝트에서는 Kingfisher를 통해 이미지 downsampling을 구현

**DownsamplingImageProcessor**

**`DownsamplingImageProcessor`** 는 고해상도 이미지를 메모리에 로드하기 전에 특정 크기로 downsampling함. 이는 **`scaleFactor`** 와 **`cacheOriginalImage`** 와 함께 사용.

- **scaleFactor**: 이미지를 축소할 비율을 지정
- **cacheOriginalImage**: 원본 이미지를 캐시에 저장할지 여부를 지정

**Kingfisher의 동작 방식**

Kingfisher에서 **`ImageProcessor`** 를 사용할 경우, 원본 이미지와 downsampling된 이미지를 각각 다른 위치에 저장함.

1. **원본 이미지**: 디스크에 저장
2. **downsampling된 이미지**: 메모리에 저장

이로 인해 원본 이미지가 메모리에 저장되지 않아서 메모리 사용량을 줄일 수 있음.

```swift

imageView.kf.setImage(
    with: resource,
    placeholder: placeholderImage,
    options: [
        .processor(DownsamplingImageProcessor(size: imageView.size)),
        .scaleFactor(UIScreen.main.scale),
        .cacheOriginalImage
    ])
```

**Downsampling**을 적용한 결과, 메모리 사용량이 `2.5GB에서 231MB`로 감소하였고, 이는 전체 메모리 사용량의 `90.76%` 감소

<img width="1512" alt="스크린샷 2024-05-22 16 01 18" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/0ae55844-208f-4e3a-b2c3-3689a1dd70ab">



+리팩토링을 진행하면서 기존의 collection view로 구현했던 chip 로직을 변경할 예정이지만, 현재 상태에서 성능을 향상시킬 수 있는 방법을 고려해봄.

### `레이아웃 계산 캐싱`

**[문제]**

**`sizeForItemAt`** 메서드는 컬렉션 뷰의 아이템마다 호출됨. 텍스트 크기 계산은 비교적 비용이 많이 드는 작업이므로 이를 매번 수행하면 앱의 성능이 떨어질 수 있음.

[해결과정]

**`temSizeCache`** 딕셔너리를 도입하여 계산된 크기를 저장하고 재사용함으로써 불필요한 연산을 줄임

`변경 전 코드`

```swift
func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
    let tagTitle = self.breadTypeTag[indexPath.item]
    let itemSize = tagTitle.size(withAttributes: [NSAttributedString.Key.font: UIFont.captionM2])
    return CGSize(width: itemSize.width + 12, height: itemSize.height)
}

```

`변경 후 코드`

```swift
 func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
        let tagTitle = breadTypeTag[indexPath.item]
        
        // 캐시에서 크기를 가져오거나 없으면 새로 계산하여 캐시에 저장
        guard let cachedSize = itemSizeCache[tagTitle.count] else {
            let itemSize = tagTitle.size(withAttributes: [NSAttributedString.Key.font: UIFont.captionM2])
            let finalSize = CGSize(width: itemSize.width + 12, height: itemSize.height)
            itemSizeCache[tagTitle.count] = finalSize
            return finalSize
        }
        
        return cachedSize
    }
```

**[결과]**

| 로그 | 
|----|
| <img width="400" alt="금양식방" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/20597523-87cb-413b-aad9-d23c42a65671"> |

| 실행 화면 | 
|----|
| <img width="150" height="280" src ="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/23605644-1c94-48b9-9b1f-b7aa634b4f4b"> |  


주어진 로그를 통해 **금양식방**은 성분 chip을 4개 가지고 있으며, **`sizeForItemAt`** 메서드가 호출될 때마다 해당 문자열에 대한 크기가 계산되고 캐시되는 것을 확인할 수 있음.

로그를 분석해보면, 처음에는 **글루텐프리** 문자열을 가진 첫 번째 셀의 크기를 계산할 때 캐시가 없어 새로 계산되고 캐시에 저장됨. 비슷하게 **비건빵** 문자열 역시 처음 계산될 때 캐시에 저장됨. 그러나 이후에는 **넛프리와 대체당** 문자열을 가진 셀에 대해서는 이미 캐시된 크기가 있기 때문에 다시 계산되지 않고 이전에 캐시된 값을 사용하여 중복 계산을 피하게됨.

각 태그 타이틀의 크기가 다르더라도 초기 계산 이후 캐시를 통해 신속하게 크기를 제공할 수 있어 중복된 계산을 최소화하고 성능을 향상시킬 수 있음을 확인할 수 있었음.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
-[베이커리 리스트 -> 상세 flow]
 객체가 메모리에서 해제되지 않는 문제가 존재하지만, 성민쿤과 리팩토링하면서 개선할 예정

<img width="1091" alt="스크린샷 2024-05-22 16 56 59" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/1441310b-4a97-4449-af2a-e48ead349868">
- 로직은,, mvvm+클린아키텍쳐 적용하면서 개선하겠슴다,, 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #260


## 📬 Reference
- wwdc 18 
- https://github.com/GEON-PPANG/GEON-PPANG-iOS/discussions/262#discussion-6709497
