### PR TITLE
[Feat] #263 - feature단위로 ci/cd 도입 

### DIFF
--- a/GEON-PPANG-iOS.xcodeproj/project.pbxproj
+++ b/GEON-PPANG-iOS.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		09CD07902A620D7D00A078DE /* NickNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CD078F2A620D7D00A078DE /* NickNameViewController.swift */; };
 		09CD07922A624B7D00A078DE /* SignInTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CD07912A624B7D00A078DE /* SignInTextField.swift */; };
 		09D55FC72A99F69000997FB4 /* BakeryCommonListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D55FC62A99F69000997FB4 /* BakeryCommonListResponseDTO.swift */; };
+		09E30E832BFEF180001E107B /* ci_post_clone.sh in Resources */ = {isa = PBXBuildFile; fileRef = 09E30E822BFEF180001E107B /* ci_post_clone.sh */; };
 		09E445332AA34F90008E3D33 /* AuthRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E445322AA34F90008E3D33 /* AuthRequestDTO.swift */; };
 		09E445352AA3A6D6008E3D33 /* BakeryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E445342AA3A6D6008E3D33 /* BakeryRequestDTO.swift */; };
 		09E445372AA3AFB1008E3D33 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E445362AA3AFB1008E3D33 /* Encodable+.swift */; };
@@ -350,6 +351,7 @@
 		09CD078F2A620D7D00A078DE /* NickNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NickNameViewController.swift; sourceTree = "<group>"; };
 		09CD07912A624B7D00A078DE /* SignInTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInTextField.swift; sourceTree = "<group>"; };
 		09D55FC62A99F69000997FB4 /* BakeryCommonListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakeryCommonListResponseDTO.swift; sourceTree = "<group>"; };
+		09E30E822BFEF180001E107B /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		09E445322AA34F90008E3D33 /* AuthRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRequestDTO.swift; sourceTree = "<group>"; };
 		09E445342AA3A6D6008E3D33 /* BakeryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakeryRequestDTO.swift; sourceTree = "<group>"; };
 		09E445362AA3AFB1008E3D33 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
@@ -930,6 +932,7 @@
 			isa = PBXGroup;
 			children = (
 				091AFD412ABD79380001DD02 /* Settings.bundle */,
+				09E30E812BFEF16F001E107B /* ci_scripts */,
 				098F32DF2A4200FD0092D09A /* GEON-PPANG-iOS */,
 				098F32DE2A4200FD0092D09A /* Products */,
 			);
@@ -1005,6 +1008,14 @@
 				3EA69C482B67F8BA008AE23B /* LoginProtocol.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		09E30E812BFEF16F001E107B /* ci_scripts */ = {
+			isa = PBXGroup;
+			children = (
+				09E30E822BFEF180001E107B /* ci_post_clone.sh */,
+			);
+			path = ci_scripts;
 			sourceTree = "<group>";
 		};
 		09F015EE2A9C87D40093D4F0 /* LogIn */ = {
@@ -1956,6 +1967,7 @@
 				094392CF2A84E68700984310 /* GoogleService-Info.plist in Resources */,
 				098F32ED2A4200FE0092D09A /* LaunchScreen.storyboard in Resources */,
 				DFDE72DB2A66893900389A51 /* Config.xcconfig in Resources */,
+				09E30E832BFEF180001E107B /* ci_post_clone.sh in Resources */,
 				098F32EA2A4200FE0092D09A /* Assets.xcassets in Resources */,
 				DF959A622A539FBE00E75774 /* Pretendard-Medium.otf in Resources */,
 				091AFD422ABD79380001DD02 /* Settings.bundle in Resources */,

--- a/GEON-PPANG-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GEON-PPANG-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,104 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
+        "version" : "5.8.1"
+      }
+    },
+    {
+      "identity" : "amplitude-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-iOS",
+      "state" : {
+        "branch" : "main",
+        "revision" : "82fc62448292c13fa0a6b0b11c4524df83fd3f3b"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "e2ca17ac735bcbc48b13062484541702ef45153d",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "ae3c60cbd4e3b348775f8c766e5b908fa1e66c5a",
+        "version" : "2.20.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "branch" : "master",
+        "revision" : "10a9dd1577c4de5135a29f99410863d2e9ee034a"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "b847a202a517a90763e8fd0656d8028aeee7b78d",
+        "version" : "8.20.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "e74fe2a978d1216c3602b129447c7301573cc2d8",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,27 @@
+//
+//  ci_post_clone.sh
+//  GEON-PPANG-iOS
+//
+//  Created by JEONGEUN KIM on 5/23/24.
+//
+
+FOLDER_PATH="/Volumes/workspace/repository/GEON-PPANG-iOS
+
+# *.xconfig 파일 이름
+CONFIG_FILENAME="Config.xcconfig"
+
+# *.xconfig 파일의 전체 경로 계산
+CONFIG_FILE_PATH="$FOLDER_PATH/$CONFIG_FILENAME"
+
+# 환경 변수에서 값을 가져와서 *.xconfig 파일에 추가하기
+{
+    echo "BASE_URL = $BASE_URL"
+    echo "NATIVE_APP_KEY = $NATIVE_APP_KEY"
+    echo "AMPLITUDE_API_KEY = $AMPLITUDE_API_KEY"
+    
+} >> "$CONFIG_FILE_PATH"
+
+# 생성된 *.xconfig 파일 내용 출력
+cat "$CONFIG_FILE_PATH"
+
+echo "Config.xcconfig 파일이 성공적으로 생성되었고, 환경변수 값이 확인되었습니다."


### PR DESCRIPTION
## 🌁 Background
 - xcode cloud를 이용해서 feature단위로 ci/cd 도입

## 📱 Screenshot
|xcode|
|----|
|<img width="500" alt="스크린샷 2024-05-23 12 51 57" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/64a5319e-d717-4eec-89c3-2fb71f214d47">|


|slack|
|----|
|<img width="500" alt="스크린샷 2024-05-23 12 52 50" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/de0af293-3657-4b5e-937c-f3f44068cdbc">|

오류 해결 후 
성공적으로 빌드 완 
<img width="1206" alt="스크린샷 2024-05-23 15 06 20" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/7f5b4c8f-4558-4c6c-ba9f-29bf985d0bea">

## 👩‍💻 Contents
- xcode cloud를 feature, develop 도입
- Xcode Cloud가 xcode build를 할 때 remote reporitory를 clone해서 빌드를 진행하기 때문에 현재 github에 올라와 있지 않은 Config파일을 찾을 수 없어서 빌드 오류로나타납니당.
- 이 문제를 해결하기 위해서 build script을 custom한 ci_post_clone.sh를 추가했습니당 .
- 머지 후에 build 성공하면 추가로 이미지 첨부하겠습니다



develop에 머지한 이후에도 오류가 발생했었는디요 ,,, 
오류가 발생한 원인은 2가지욧슴돠 
1.  스크립트를 실행할 때 사용해야하는 인터프리터를 결정해주는 역할인 shebang을 포함하지 않음
2. Config 파일 경로를 잘못 설정
`FOLDER_PATH="/Volumes/workspace/repository/GEON-PPANG-iOS/Resource"
`
.xconfig 파일의 전체 경로 계산을 하기위해서 폴더 경로를 설정하는 과정에서 잘못설정하여 오류가 발생한 것 ,, 

## ✅ Testing
- 슬랙과 연동해 두어 아요 ci/cd를 통해서 빌드 결과 확인 가능 
- xcodeㅇ에서도 확인 가능 
<img width="289" alt="스크린샷 2024-05-23 12 48 02" src="https://github.com/GEON-PPANG/GEON-PPANG-iOS/assets/107853954/63c2b0c1-9b6b-45f8-8876-b2c6515697d1">

## 📝 Review Note
- xcode cloud를 도입하면서 GUI 환경으로 손쉽게 환경 구축 가능하고, Apple에서 지원하는 CI/CD 툴이기 때문에 안정성 측면에서 다른 Ci/CD 툴보다 좋은 것 같슴다 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #263


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
